### PR TITLE
Fix bitcode problem exporting with xcodebuild.

### DIFF
--- a/src/main/resources/org/moe/generator/project/moe.build.script.sh.in
+++ b/src/main/resources/org/moe/generator/project/moe.build.script.sh.in
@@ -61,6 +61,11 @@ fi
 # Copy and sign MOE framework
 rsync -av --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" \
     "${MOE_FRAMEWORK_PATH}/MOE.framework" "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/"
+# Strip the bitcode section & segment as would be done when STRIP_BITCODE_FROM_COPIED_FILES is enabled
+if [ "${STRIP_BITCODE_FROM_COPIED_FILES}" != "NO" ]; then
+	xcrun bitcode_strip -r "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MOE.framework/MOE" -o "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MOE.framework/MOE"
+fi
+
 if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" -a "${CODE_SIGNING_REQUIRED}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
     /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY $OTHER_CODE_SIGN_FLAGS \
         --preserve-metadata=identifier,entitlements "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MOE.framework"


### PR DESCRIPTION
Exporting archive using xcodebuild -exportOptionsPlist is
failing with the 1.3 release of Multi-OS Engine. The export
fails with an error like this:

Error Domain=IDEDistributionErrorDomain Code=14 "No applicable devices
found." UserInfo={NSLocalizedDescription=No applicable devices found.}

More details in IDEDistribution.standard.log:

"Failed to verify bitcode in MOE.framework/MOE:\nerror: Bundle only
contains bitcode-marker
/var/folders/vb/zpw1mfn94yj6rq6s7byp403r0000gn/T/IDEDistributionThinningStep.qN8/Payload/testfoo.app/Frameworks/MOE.framework/MOE
(armv7)\n\n";

The root problem is that the following file contains a bitcode marker
section, which was not present when using Multi-OS engine 1.2.5:

build/moe/xcodebuild/Release-iphoneos/testfoo.app/Frameworks/MOE.framework/MOE

You can see the section by running the following command:

xcrun size -x -m -l MOE

The difference between 1.2.5 and 1.3 is that 1.2.5 was embedding
the MOE.framework using the xcode project configuration, which
copied the framework with STRIP_BITCODE_FROM_COPIED_FILES set to
the default YES. This stripped out the bitcode marker section
and segment. However 1.3 is copying the framework using a build
script, which doesn't strip out the section.

This commit adds a call to strip out the bitcode from the framework
using the 'bitcode_strip' tool.